### PR TITLE
Support linker args when building in a static project.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,25 @@ fn main() {
     let include_dir = env::var("LIBARCHIVE_INCLUDE_DIR").ok();
 
     if lib_dir.is_some() && include_dir.is_some() {
-        println!("cargo:rustc-link-search=native={}", lib_dir.unwrap());
+        println!("cargo:rustc-flags=-L native={}", lib_dir.unwrap());
         println!("cargo:include={}", include_dir.unwrap());
         let mode = match env::var_os("LIBARCHIVE_STATIC") {
             Some(_) => "static",
             None => "dylib",
         };
         println!("cargo:rustc-flags=-l {0}=archive", mode);
+
+        if mode == "static" {
+            if let Ok(ldflags) = env::var("LIBARCHIVE_LDFLAGS") {
+                for token in ldflags.split_whitespace() {
+                    if token.starts_with("-L") {
+                        println!("cargo:rustc-flags=-L native={}", token.replace("-L", ""));
+                    } else if token.starts_with("-l") {
+                        println!("cargo:rustc-flags=-l static={}", token.replace("-l", ""));
+                    }
+                }
+            }
+        }
     } else {
         match pkg_config::find_library("libarchive") {
             Ok(_) => (),


### PR DESCRIPTION
This change looks for the `LIBARCHIVE_LDFLAGS` environment variable, but
only when `LIBARCHIVE_STATIC` is set. This allows us to pass the libaray
path for some of libarchive's dependencies (assuming they are built in),
such as zlib, bzip2, xz, openssl, etc. The `-L` entries are a path
containing the static archive (i.e. `*.a`) and the `-l` entries are the
specific libraries to link against.

Here's an example invocation of `cargo build`:

``` sh
env \
  LIBARCHIVE_LIB_DIR=/usr/local/musl/libarchive/lib \
  LIBARCHIVE_INCLUDE_DIR=/usr/local/musl/libarchive/include \
  LIBARCHIVE_LDFLAGS="-L/usr/local/musl/xz/lib -llzma -L/usr/local/musl/zlib/lib -lz" \
  LIBARCHIVE_STATIC=true \
  cargo build --target=x86_64-unknown-linux-musl
```

Without knowing where these libararies live, the linker only finds
missing symbols when assembing the final binary. Don't even ask how I've
figure this out... ;)
