### PR TITLE
Fix MinGW build.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -40,6 +40,9 @@ pub enum Struct_archive_entry { }
 pub enum Struct_archive_acl { }
 pub enum Struct_archive_entry_linkresolver { }
 
+#[cfg(windows)]
+pub type mode_t = u16;
+
 pub type archive_read_callback = unsafe extern "C" fn(arg1: *mut Struct_archive,
                                                       _client_data: *mut c_void,
                                                       _buffer: *mut *const c_void)


### PR DESCRIPTION
On Windows, libc does not contain a mode_t type. Furthermore, the libarchive/archive.h defines its own unsigned 16 bit mode_t type on Windows (see https://github.com/libarchive/libarchive/blob/167e97be1d35c1e0947d768adbf94712244aad6b/libarchive/archive_entry.h#L72 and  https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751%28v=vs.85%29.aspx#short).

With this change, libarchive-rust builds on MSYS2 using MinGW, as long as pkg-config is setup for the appropriate toolchain.
